### PR TITLE
Remove support for Active Record 5.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
+.irb_history
+.DS_Store
 /.bundle/
+/.claude/
 /.yardoc
 /Gemfile.lock
 /_yardoc/

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rails'
+gem 'rails', '~> 8.0'
 
 # Specify your gem's dependencies in devise-multi_email.gemspec
 gemspec

--- a/devise-multi_email.gemspec
+++ b/devise-multi_email.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'devise'
 
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'capybara'

--- a/gemfiles/rails_5_1.gemfile
+++ b/gemfiles/rails_5_1.gemfile
@@ -1,5 +1,0 @@
-source "https://rubygems.org"
-
-gem "rails", "~> 5.1.1"
-
-gemspec path: "../"

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -1,5 +1,0 @@
-source "https://rubygems.org"
-
-gem "rails", "~> 5.2.0"
-
-gemspec path: "../"

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -1,5 +1,0 @@
-source "https://rubygems.org"
-
-gem "rails", ">= 6.0.2.1", "< 6.1"
-
-gemspec path: "../"

--- a/lib/devise/multi_email/models/validatable.rb
+++ b/lib/devise/multi_email/models/validatable.rb
@@ -7,13 +7,8 @@ module Devise
 
       included do
         validates_presence_of   :email, if: :email_required?
-        if Devise.activerecord51?
-          validates_uniqueness_of :email, allow_blank: true, case_sensitive: true, if: :will_save_change_to_email?
-          validates_format_of     :email, with: email_regexp, allow_blank: true, if: :will_save_change_to_email?
-        else
-          validates_uniqueness_of :email, allow_blank: true, if: :email_changed?
-          validates_format_of     :email, with: email_regexp, allow_blank: true, if: :email_changed?
-        end
+        validates_uniqueness_of :email, allow_blank: true, if: :email_changed?
+        validates_format_of     :email, with: email_regexp, allow_blank: true, if: :email_changed?
       end
 
       def email_required?

--- a/spec/orm/active_record.rb
+++ b/spec/orm/active_record.rb
@@ -1,12 +1,4 @@
 ActiveRecord::Migration.verbose = false
 
 migration_path = File.expand_path('../../rails_app/db/migrate/', __FILE__)
-# https://github.com/plataformatec/devise/blob/master/test/orm/active_record.rb
-# Run any available migration
-if Rails.version.start_with? '6'
-  ActiveRecord::MigrationContext.new(migration_path, ActiveRecord::SchemaMigration).migrate
-elsif Rails.version.start_with? '5.2'
-  ActiveRecord::MigrationContext.new(migration_path).migrate
-else
-  ActiveRecord::Migrator.migrate(migration_path)
-end
+ActiveRecord::MigrationContext.new(migration_path).migrate

--- a/spec/rails_app/config/application.rb
+++ b/spec/rails_app/config/application.rb
@@ -1,9 +1,6 @@
 require File.expand_path('../boot', __FILE__)
 
-require 'action_controller/railtie'
-require 'action_mailer/railtie'
-require 'active_record/railtie'
-require 'rails/test_unit/railtie'
+require 'rails/all'
 
 require 'devise/multi_email'
 

--- a/spec/rails_app/config/boot.rb
+++ b/spec/rails_app/config/boot.rb
@@ -1,3 +1,3 @@
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../../Gemfile', __FILE__)
-require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])

--- a/spec/rails_app/config/environments/development.rb
+++ b/spec/rails_app/config/environments/development.rb
@@ -1,30 +1,42 @@
-RailsApp::Application.configure do
+# frozen_string_literal: true
+
+Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  # In the development environment your application's code is reloaded on
-  # every request. This slows down response time but is perfect for development
-  # since you don't have to restart the web server when you make code changes.
-  config.cache_classes = false
+  # Make code changes take effect immediately without server restart.
+  config.enable_reloading = true
 
   # Do not eager load code on boot.
   config.eager_load = false
 
-  # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  # Show full error reports.
+  config.consider_all_requests_local = true
+
+  # Enable server timing.
+  config.server_timing = true
+
   config.action_controller.perform_caching = false
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.cache_store = :null_store
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 
-  # Only use best-standards-support built into browsers.
-  config.action_dispatch.best_standards_support = :builtin
-
-  # Raise an error on page load if there are pending migrations
+  # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
 
-  # Debug mode disables concatenation and preprocessing of assets.
-  config.assets.debug = true
+  # Highlight code that triggered database queries in logs.
+  config.active_record.verbose_query_logs = true
+
+  # Append comments with runtime information tags to SQL queries in logs.
+  config.active_record.query_log_tags_enabled = true
+
+  # Highlight code that enqueued background job in logs.
+  config.active_job.verbose_enqueue_logs = true
+
+  # Annotate rendered view with file names.
+  config.action_view.annotate_rendered_view_with_filenames = true
+
+  # Raise error when a before_action's only/except options reference missing actions.
+  config.action_controller.raise_on_missing_callback_actions = true
 end

--- a/spec/rails_app/config/environments/production.rb
+++ b/spec/rails_app/config/environments/production.rb
@@ -1,84 +1,47 @@
-RailsApp::Application.configure do
+# frozen_string_literal: true
+
+Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.
-  config.cache_classes = true
+  config.enable_reloading = false
 
-  # Eager load code on boot. This eager loads most of Rails and
-  # your application in memory, allowing both thread web servers
-  # and those relying on copy on write to perform better.
-  # Rake tasks automatically ignore this option for performance.
+  # Eager load code on boot for better performance and memory savings (ignored by Rake tasks).
   config.eager_load = true
 
-  # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
+  # Full error reports are disabled.
+  config.consider_all_requests_local = false
+
+  # Turn on fragment caching in view templates.
   config.action_controller.perform_caching = true
 
-  # Enable Rack::Cache to put a simple HTTP cache in front of your application
-  # Add `rack-cache` to your Gemfile before enabling this.
-  # For large-scale production use, consider using a caching reverse proxy like nginx, varnish or squid.
-  # config.action_dispatch.rack_cache = true
-
-  # Disable Rails's static asset server (Apache or nginx will already do this).
-  if Rails.version >= "4.2.0"
-    config.serve_static_files = false
-  else
-    config.serve_static_assets = false
-  end
-
-  # Compress JavaScripts and CSS.
-  config.assets.js_compressor  = :uglifier
-  # config.assets.css_compressor = :sass
-
-  # Whether to fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
-
-  # Generate digests for assets URLs.
-  config.assets.digest = true
-
-  # Version of your assets, change this if you want to expire all your assets.
-  config.assets.version = '1.0'
-
-  # Specifies the header that your server uses for sending files.
-  # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for apache
-  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
+  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
+  config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  # CloudFlare handles SSL termination for us. Forcing it at the Rails layer will cause an infinite
+  # redirect loop.
+  config.force_ssl = false
 
-  # Set to :debug to see everything in the log.
-  config.log_level = :info
+  # Log to STDOUT with the current request id as a default log tag.
+  config.log_tags = [:request_id]
+  config.logger = ActiveSupport::Logger.new($stdout)
 
-  # Prepend all log lines with the following tags.
-  # config.log_tags = [:subdomain, :uuid]
+  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 
-  # Use a different logger for distributed setups.
-  # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
+  # Don't log any deprecations.
+  config.active_support.report_deprecations = false
 
-  # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
-
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = "http://assets.example.com"
-
-  # Precompile additional assets.
-  # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-  # config.assets.precompile += %w( search.js )
-
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  # Replace the default in-process memory cache store with a durable alternative.
+  config.cache_store = :null_store
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
-  # the I18n.default_locale when a translation can not be found).
+  # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
 
-  # Send deprecation notices to registered listeners.
-  config.active_support.deprecation = :notify
+  # Do not dump schema after migrations.
+  config.active_record.dump_schema_after_migration = false
 
-  # Disable automatic flushing of the log to improve performance.
-  # config.autoflush_log = false
-
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
+  # Only use :id for inspections in production.
+  config.active_record.attributes_for_inspect = [:id]
 end

--- a/spec/rails_app/config/environments/test.rb
+++ b/spec/rails_app/config/environments/test.rb
@@ -1,52 +1,44 @@
-RailsApp::Application.configure do
+# frozen_string_literal: true
+
+# The test environment is used exclusively to run your application's
+# test suite. You never need to work with it otherwise. Remember that
+# your test database is "scratch space" for the test suite and is wiped
+# and recreated between test runs. Don't rely on the data there!
+
+Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  # The test environment is used exclusively to run your application's
-  # test suite. You never need to work with it otherwise. Remember that
-  # your test database is "scratch space" for the test suite and is wiped
-  # and recreated between test runs. Don't rely on the data there!
-  config.cache_classes = true
+  # While tests run files are not watched, reloading is not necessary.
+  config.enable_reloading = false
 
-  # Do not eager load code on boot. This avoids loading your whole application
-  # just for the purpose of running a single test. If you are using a tool that
-  # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = false
+  # Eager loading loads your entire application. When running a single test locally,
+  # this is usually not necessary, and can slow down your test suite. However, it's
+  # recommended that you enable it in continuous integration systems to ensure eager
+  # loading is working properly before deploying your code.
+  config.eager_load = ENV["CI"].present?
 
-  # Disable serving static files from the `/public` folder by default since
-  # Apache or NGINX already handles this.
-  if Rails.version >= '4.2.0'
-    config.serve_static_files = true
-  else
-    config.serve_static_assets = true
-  end
+  # Show full error reports.
+  config.consider_all_requests_local = true
 
-  if Rails.version >= '5.0.0'
-    config.public_file_server.headers = {'Cache-Control' => 'public, max-age=3600'}
-  else
-    config.static_cache_control = 'public, max-age=3600'
-  end
+  config.cache_store = :null_store
 
-  if Rails.version >= '5.2.0' && Rails.version < '6.0'
-    config.active_record.sqlite3.represent_boolean_as_integer = true
-  end
-
-  # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
-
-  # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  # Render exception templates for rescuable exceptions and raise for other exceptions.
+  config.action_dispatch.show_exceptions = :rescuable
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
 
-  # Tell Action Mailer not to deliver emails to the real world.
-  # The :test delivery method accumulates sent emails in the
-  # ActionMailer::Base.deliveries array.
-  config.action_mailer.delivery_method = :test
-
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
-  config.active_support.test_order = :random
+  # Raise error when a before_action's only/except options reference missing actions.
+  config.action_controller.raise_on_missing_callback_actions = true
+
+  # ActionMailer configuration for tests
+  config.action_mailer.delivery_method = :test
+  config.action_mailer.default_url_options = { host: 'www.example.com', port: 3000 }
+  config.action_mailer.asset_host = 'http://www.example.com:3000'
+
+  # Set default URL options for all route helpers
+  config.action_controller.default_url_options = { host: 'www.example.com', port: 3000 }
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,10 +5,19 @@ require 'capybara/rspec'
 require 'rails_app/config/environment'
 require 'orm/active_record'
 
+# Reload routes to ensure Devise mappings are available in test environment
+Rails.application.reload_routes!
+
+# I haven't worked out why this is needed. Without it, the user routes don't exist, but it requires
+# both the `reload_routes!` above plus this one after initialize
+Rails.application.config.after_initialize do
+  Rails.application.reload_routes!
+end
+
 Capybara.app = RailsApp::Application
 
 RSpec.configure do |config|
-  config.include RailsApp::Application.routes.url_helpers
+  config.include Rails.application.routes.url_helpers
 end
 
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }


### PR DESCRIPTION
The official devise-multi_email gem has been throwing deprecation warnings saying:

> DEPRECATION WARNING: [Devise] `Devise.activerecord51?` is deprecated and will be removed in the next major version.
> It is a non-public method that's no longer used internally, but that other libraries have been relying on.
> (called from <class:User> at [path to root dir]/app/models/user.rb:44)

Unfortunately, the project hasn't been maintained for 3 years, so I've forked it and upgraded the gem. While it would have been possible to simply replace `Devise.activerecord51?` with something else, given this repo will only be used by Ruby Australia, I've opted for removing support for old versions of both Ruby and Rails